### PR TITLE
Updated quest button loop to reflect 8.0 API changes

### DIFF
--- a/QuestLevel.lua
+++ b/QuestLevel.lua
@@ -23,8 +23,7 @@ function AutoTurnIn:ShowQuestLevelInLog()
 		return
 	end	
 
-	for i = 1, #QuestMapFrame.QuestsFrame.Contents.Titles do
-		local button = QuestMapFrame.QuestsFrame.Contents.Titles[i]
+	for button in QuestMapFrame.QuestsFrame.titleFramePool:EnumerateActive() do
 		if (button and button.questLogIndex) then
 			local title, level, suggestedGroup, isHeader, isCollapsed, isComplete, frequency, questID,
 				  startEvent, displayQuestID, isOnMap, hasLocalPOI, isTask, isStory = GetQuestLogTitle(button.questLogIndex)


### PR DESCRIPTION
`QuestMapFrame.QuestsFrame.Contents.Titles` no longer exists. The title buttons can now be found from the return value of  `QuestMapFrame.QuestsFrame.titleFramePool:EnumerateActive()`.

This fixes the world map quest level feature for 8.0 (tested on the beta in 8.0.1.27075). Before this fix an LUA error is caused every time the world map quest list is updated.

Proof of fix:

https://i.imgur.com/Wab400W.png