### PR TITLE
Provide an option to dismiss the Kyrian Steward automatically

### DIFF
--- a/AutoTurnIn.lua
+++ b/AutoTurnIn.lua
@@ -159,7 +159,13 @@ function AutoTurnIn:RegisterGossipEvents()
 			StaticPopup1Button1:Click() 
 		end 
 	end
-	
+	local gossipFunc5 = function() 
+		if AutoTurnInCharacterDB.dismisskyriansteward then
+			AutoTurnIn:Print(L["ivechosenfive"])
+			C_GossipInfo.SelectOption(5)
+		end
+	end
+
 	AutoTurnIn.knownGossips = {
 		["93188"]=gossipFunc1, -- Mongar
 		["96782"]=gossipFunc1, -- Lucian Trias
@@ -170,6 +176,7 @@ function AutoTurnIn:RegisterGossipEvents()
 		["54334"]=gossipFunc3, -- travel to Darkmoon
 		["55382"]=gossipFunc3, -- travel to Darkmoon
 		["57850"]=gossipFunc4, -- DarkmoonFaireTeleportologist
+		["166663"]=gossipFunc5, -- Kyrian Steward
 	}
 end
 

--- a/AutoTurnIn.toc
+++ b/AutoTurnIn.toc
@@ -1,6 +1,6 @@
 ## Interface: 90205
 ## Title: AutoTurnIn
-## Version: 7.5.2
+## Version: 7.5.3
 ## Author: Alex Shubert
 ## Notes: Quest handling automation
 ## Notes-ruRU: Автоматическая обработка заданий

--- a/loc/localization_DE.lua
+++ b/loc/localization_DE.lua
@@ -39,7 +39,9 @@ privateTable.L = setmetatable({
 
 	["ReviveBattlePetLabel"]="Kampfhaustier heilen",
 	["ReviveBattlePetQ"]="Ich würde gern meine Kampfhaustiere heilen und wiederbeleben.",
-	["ReviveBattlePetA"]="Es wird eine kleine Gebühr für die medizinische Hilfe erhoben.",
+	["ReviveBattlePetA"]="Es wird eine kleine Gebühr für die medizinische Hilfe erhoben.",,
+	
+	["DismissKyrianStewardLabel"]="Entlässt Kyrian Steward.",
 	
 	["The Jade Forest"]="Der Jadewald",
 	["Scared Pandaren Cub"]="verängstigte Pandarenkinder",
@@ -60,7 +62,8 @@ privateTable.L = setmetatable({
 	["stopitemfound"]="Gefunden: %s. Ihr müsst eine Belohnung manuell auswählen und ausrüsten.",
 	["relictoggle"]="Deaktivieren Relikt Belohnung plündern",
 	["artifactpowertoggle"]="Deaktivieren Artefaktmacht plündern",	
-	["ivechosen"]="I have chosen first option for you.",	
+	["ivechosen"]="Ich habe die erste Option für Sie ausgewählt.",
+	["ivechosenfive"]="Ich habe die fünfte Option für Sie ausgewählt.",	
 	["norewardsettings"]="No reward preferences found. Auto equipping disabled.",
 	["ignorenpc"]="Ignoriere diesen Charakter",
 	["cantstopignore"]="Ich kann nicht aufhören, diesen Charakter zu ignorieren",

--- a/loc/localization_EN.lua
+++ b/loc/localization_EN.lua
@@ -52,6 +52,8 @@ privateTable.L = setmetatable({
 	["ReviveBattlePetQ"]="I'd like to heal and revive my battle pets.",
 	["ReviveBattlePetA"]="A small fee for supplies is required.",
 	
+	["DismissKyrianStewardLabel"]="Dismiss Kyrian Steward.",
+
 	["The Jade Forest"]="The Jade Forest",
     ["Scared Pandaren Cub"]="Scared Pandaren Cub",
 	
@@ -71,7 +73,8 @@ privateTable.L = setmetatable({
 	["stopitemfound"]="There is %s in rewards. Choose and equip an item yourself.",
 	["relictoggle"]="Disable relic reward autoloot",
 	["artifactpowertoggle"]="Disable artifact power reward autoloot",
-	["ivechosen"]="I have chosen first option for you.",
+	["ivechosen"]="I have chosen the first option for you.",
+	["ivechosenfive"]="I have chosen the fifth option for you.",
 	["norewardsettings"]="No reward preferences found. Auto equipping disabled.",
 	["ignorenpc"]="Ignore this NPC",
 	["cantstopignore"]="Can't stop ignoring this NPC",

--- a/loc/localization_FR.lua
+++ b/loc/localization_FR.lua
@@ -40,7 +40,9 @@ privateTable.L = setmetatable({
 
 	["ReviveBattlePetLabel"]="Soigner les mascottes de combat",
 	["ReviveBattlePetQ"]="I'd like to heal and revive my battle pets.",
-	["ReviveBattlePetA"]="A small fee for supplies is required.",
+	["ReviveBattlePetA"]="A small fee for supplies is required.",,
+	
+	["DismissKyrianStewardLabel"]="Renvoyer Kyrian Steward.",
 	
     ["The Jade Forest"]="La forêt de Jade",
     ["Scared Pandaren Cub"]="Bébé pandaren apeuré",
@@ -61,7 +63,8 @@ privateTable.L = setmetatable({
     ["stopitemfound"]="Il y a %s en récompense. Choisissez et équiper un objet.",
 	["relictoggle"]="Désactiver relique récompense butin",
 	["artifactpowertoggle"]="Désactiver puissance de l'artefact butin",
-	["ivechosen"]="I have chosen first option for you.",
+	["ivechosen"]="J'ai choisi la première option pour vous.",
+    ["ivechosenfive"]="J'ai choisi la cinquième option pour vous.",
 	["norewardsettings"]="No reward preferences found. Auto equipping disabled.",
 	["ignorenpc"]="Ignorer ce personnage",
 	["cantstopignore"]="Je ne peux pas arrêter d'ignorer ce personnage",

--- a/loc/localization_IT.lua
+++ b/loc/localization_IT.lua
@@ -40,7 +40,9 @@ privateTable.L = setmetatable({
 	
 	["ReviveBattlePetLabel"]="Guarigione Mascotte da Combattimento",
 	["ReviveBattlePetQ"]="I'd like to heal and revive my battle pets.",
-	["ReviveBattlePetA"]="A small fee for supplies is required.",
+	["ReviveBattlePetA"]="A small fee for supplies is required.",,
+	
+	["DismissKyrianStewardLabel"]="Уволить Кириана Стюарда.",
 	
 	["The Jade Forest"]="Foresta di Giada",
 	["Scared Pandaren Cub"]="Cucciolo Pandaren Spaventato",
@@ -61,7 +63,8 @@ privateTable.L = setmetatable({
 	["stopitemfound"]="There is %s in rewards. Choose and equip an item yourself.",
 	["relictoggle"]="Disabilitare selezione direliquia ricompensa",
 	["artifactpowertoggle"]="Disabilitare selezione di Potere Artefatto ricompensa",
-	["ivechosen"]="I have chosen first option for you.",
+	["ivechosen"]="Ho scelto per te la prima opzione",
+	["ivechosenfive"]="Ho scelto per te la quinta opzione",
 	["norewardsettings"]="No reward preferences found. Auto equipping disabled.",
 	["ignorenpc"]="Ignora questo personaggio",
 	["cantstopignore"]="Non riesco a smettere di ignorare questo personaggio",

--- a/loc/localization_RU.lua
+++ b/loc/localization_RU.lua
@@ -39,7 +39,9 @@ privateTable.L = setmetatable({
 	
 	["ReviveBattlePetLabel"]="Лечение боевых питомцев",
 	["ReviveBattlePetQ"]="Мне бы хотелось воскресить и исцелить моих боевых питомцев.",
-	["ReviveBattlePetA"]="За это надо бы и заплатить немножко.",
+	["ReviveBattlePetA"]="За это надо бы и заплатить немножко.",,
+	
+	["DismissKyrianStewardLabel"]="Dismiss Kyrian Steward.",
 	
 	["The Jade Forest"]="Нефритовый лес",
 	["Scared Pandaren Cub"]="Испуганный юный пандарен",
@@ -61,6 +63,7 @@ privateTable.L = setmetatable({
 	["relictoggle"]="Отключить автолут Релика",
 	["artifactpowertoggle"]="Отключить автолут Силы Артефакта",
 	["ivechosen"]="выбрал первую опцию за тебя",
+	["ivechosenfive"]="выбрал пятый вариант для вас",
 	["norewardsettings"]="Не выбраны желаемые награды. Автоодевание отключено.",
 	["ignorenpc"]="Игнорировать персонажа",
 	["cantstopignore"]="Этого персонажа нельзя перестать игнорировать",

--- a/ui/main_options.lua
+++ b/ui/main_options.lua
@@ -96,6 +96,8 @@ local RelicToggle = newCheckbox("RelicToggle",  L["relictoggle"], "relictoggle")
 local ArtifactPowerToggle = newCheckbox("ArtifactPowerToggle",  L["artifactpowertoggle"], "artifactpowertoggle")
 -- RevivePets
 local ReviveBattlePet = newCheckbox("ReviveBattlePet", L["ReviveBattlePetLabel"], "reviveBattlePet")
+-- Dismiss the Kyrian Steward instantly
+local DismissKyrianSteward = newCheckbox("DismissKyrianSteward", L["DismissKyrianStewardLabel"], "dismisskyriansteward")
 
 -- Auto toggle key
 local ToggleKeyConst = {NONE_KEY, ALT_KEY, CTRL_KEY, SHIFT_KEY}
@@ -128,6 +130,7 @@ ToDarkMoon:SetPoint("TOPLEFT", ShowRewardText, "BOTTOMLEFT", 0, -10)
 DarkMoonCannon:SetPoint("TOPLEFT", ToDarkMoon, "BOTTOMLEFT", 0, -10)
 DarkMoonAutoStart:SetPoint("TOPLEFT", DarkMoonCannon, "BOTTOMLEFT", 0, -10)
 ReviveBattlePet:SetPoint("TOPLEFT", CompleteOnly, "BOTTOMLEFT", 0, -30)
+DismissKyrianSteward:SetPoint("TOPLEFT", CompleteOnly, "BOTTOMLEFT", 0, -70)
 Debug:SetPoint("TOPLEFT", ResetButton, "BOTTOMLEFT", 0, -10)
 ToggleKeyDropDown:SetPoint("TOPLEFT", DarkMoonAutoStart, "BOTTOMLEFT", -15, -22)
 ShowQuestLevel:SetPoint("TOPLEFT", ToggleKeyDropDown, "BOTTOMLEFT", 16, -10)
@@ -164,6 +167,7 @@ OptionsPanel.refresh = function()
 	ShareQuests:SetChecked(ptable.TempConfig.questshare)
 	RelicToggle:SetChecked(ptable.TempConfig.relictoggle)
 	ArtifactPowerToggle:SetChecked(ptable.TempConfig.artifactpowertoggle)	
+	DismissKyrianSteward:SetChecked(ptable.TempConfig.dismisskyriansteward)
 
 	UIDropDownMenu_SetSelectedID(ToggleKeyDropDown, ptable.TempConfig.togglekey)
 	UIDropDownMenu_SetText(ToggleKeyDropDown, ToggleKeyConst[ptable.TempConfig.togglekey])


### PR DESCRIPTION
## Rationale
Hey I find that dismissing the Steward is annoying to do automatically. I'm not sure if you consider this in scope of the Addon because we technically don't turn something in, but I find it useful to have all my auto-accepts in one place! Please let me know what you think!

## Changes:
* Updated AutoTurnIn.lua to include a new registered gossip event for the Kyrian Steward
* Added a main_option for dimsissal
* Updated "ivechosen" labels for FR, DE, IT
* Added labels for "ivechosenfifth" for all locals
* Added labels for "DismissKyrianStewardLabel" for all locals
* Version to 7.5.3

---
Edit: added a version bump