### PR TITLE
Handle trivial no title quest

### DIFF
--- a/AutoTurnIn.lua
+++ b/AutoTurnIn.lua
@@ -422,13 +422,13 @@ function AutoTurnIn:GOSSIP_SHOW()
 	self:HandleGossip()
 end
 
+local trivialNoText = {}
 function AutoTurnIn:QUEST_DETAIL()
 	if (QuestIsDaily() or QuestIsWeekly()) then
 		self:CacheAsDaily(GetTitleText())
 	end
 	if QuestGetAutoAccept() then
-		CloseQuest()
-	
+		CloseQuest()	
 	else
 		if self:AllowedToHandle() and self:isAppropriate() and (not AutoTurnInCharacterDB.completeonly) then
 			--ignore trivial quests 
@@ -441,14 +441,22 @@ function AutoTurnIn:QUEST_DETAIL()
 		end
 		--quest level on detail frame
 		if AutoTurnInCharacterDB.questlevel then 
-			local level = C_QuestLog.GetQuestDifficultyLevel(GetQuestID())
+			local qid = GetQuestID()
+			local level = C_QuestLog.GetQuestDifficultyLevel(qid)
 			--sometimes it returns 0, but that's wrong
-			if level and level > 0 then 
-				local levelFormat = "[%d] %s"
+			if level and level > 0 then 			
 				local text = QuestInfoTitleHeader:GetText()
-				--trivial display
-				if C_QuestLog.IsQuestTrivial(GetQuestID()) then text = TRIVIAL_QUEST_DISPLAY:format(text) end
-				QuestInfoTitleHeader:SetText(levelFormat:format(level, text))
+				if text then -- there are reports (unconfirmed) that some trivial quests return nil for text
+					local levelFormat = "[%d] %s"
+					--trivial display
+					if C_QuestLog.IsQuestTrivial(qid) then text = TRIVIAL_QUEST_DISPLAY:format(text) end
+					QuestInfoTitleHeader:SetText(levelFormat:format(level, text))
+				else
+					if (not not trivialNoText[qid]) then
+						trivialNoText[qid] = true
+						self:Print("[AutoTurnIn] Quest has nil title [" .. qid .. "]. Could you please report it to AutoTurnIn author?")						
+					end
+				end
 			end
 		end
 	end


### PR DESCRIPTION
The [report](https://www.curseforge.com/wow/addons/autoturnin?comment=688) implies there could be trivial quests with title set to `nil`. This MR will bypass them unchanged printing the request to report them to author. 
It could easily be network issue, though. 
